### PR TITLE
Update fairytails.js to support history and continue

### DIFF
--- a/fairytails.js
+++ b/fairytails.js
@@ -1,13 +1,14 @@
-const puppeteer = require('puppeteer');
-const request = require('request');
-const fs = require('fs');
-const axios = require('axios');
-const yargs = require('yargs');
-const { hideBin } = require('yargs/helpers')
+const puppeteer = require("puppeteer");
+const request = require("request");
+const fs = require("fs");
+const axios = require("axios");
+const yargs = require("yargs");
+const { hideBin } = require("yargs/helpers");
 
-const MEDIA_URL = 'https://api.rtvslo.si/ava/getMedia';
-const FAIRY_TAIL_URL = 'https://ziv-zav.rtvslo.si/predvajaj/lahko-noc-otroci';
-const FAIRY_TAIL_API_ENDPOINT = 'https://api.rtvslo.si/ava/getSearch2?client_id=82013fb3a531d5414f478747c1aca622&showId=54&clip=show&sort=date&order=desc'
+const MEDIA_URL = "https://api.rtvslo.si/ava/getMedia";
+const FAIRY_TAIL_URL = "https://ziv-zav.rtvslo.si/predvajaj/lahko-noc-otroci";
+const FAIRY_TAIL_API_ENDPOINT =
+  "https://api.rtvslo.si/ava/getSearch2?client_id=82013fb3a531d5414f478747c1aca622&showId=54&clip=show&sort=date&order=desc";
 
 async function getMediaUrl(url) {
   let mp3Url = null;
@@ -15,7 +16,7 @@ async function getMediaUrl(url) {
   const page = await browser.newPage();
   await page.setRequestInterception(true);
 
-  page.on('request', (interceptedRequest) => {
+  page.on("request", (interceptedRequest) => {
     if (interceptedRequest.isInterceptResolutionHandled()) {
       return;
     }
@@ -60,16 +61,43 @@ async function getMp3Url(url) {
   }
 }
 
-async function downloadMp3(id, title) {
+async function downloadMp3(id, title, date) {
   const url = `${FAIRY_TAIL_URL}/${id}`;
+  const filePath = `downloads/${title}.mp3`;
+
+  // // Check if file already exists in the downloads directory
+  // if (fs.existsSync(filePath)) {
+  //   console.log(`File ${filePath} already exists.`);
+  //   return true;
+  // }
+
+  // Read the downloaded.txt file and check if the title already exists
+  let downloadedTitles = [];
+  if (fs.existsSync("downloaded.txt")) {
+    downloadedTitles = fs.readFileSync("downloaded.txt", "utf8").split("\n");
+  }
+  if (downloadedTitles.includes(title)) {
+    console.log(`Title "${title}" already exists in downloaded.txt.`);
+    return true;
+  }
 
   try {
     const mp3Url = await getMp3Url(url);
-    request.get(mp3Url).pipe(fs.createWriteStream(`downloads/${title}.mp3`));
-    console.log(title + ' downloading...');
+    request.get(mp3Url).pipe(fs.createWriteStream(filePath));
+
+    // After successful try execution, store the title in a downloaded.txt file
+    fs.appendFile("downloaded.txt", title + "\n", function (err) {
+      if (err) throw err;
+    });
   } catch (err) {
     console.log(err);
   }
+
+  fs.writeFile("date.txt", date, function (err) {
+    if (err) throw err;
+  });
+
+  return false;
 }
 
 //downloadMp3("https://ziv-zav.rtvslo.si/predvajaj/lahko-noc-otroci/174867111");
@@ -84,7 +112,7 @@ async function scrapeFairyTaleIds(url) {
     const match = websiteContent.match(regex);
     return [...new Set(match)];
   } catch (err) {
-    console.log('Could not resolve the browser instance => ', err);
+    console.log("Could not resolve the browser instance => ", err);
   }
 }
 
@@ -92,40 +120,91 @@ async function getFairyTales(last = 1) {
   return axios
     .get(FAIRY_TAIL_API_ENDPOINT, {
       params: {
-        pageSize: last
-      }
+        pageSize: last,
+      },
     })
-    .then(res => {
-      return res.data.response.recordings
+    .then((res) => {
+      return res.data.response.recordings;
     })
-    .catch(error => {
+    .catch((error) => {
       console.error(error);
     });
 }
 
 async function downloadLastFairyTale() {
   const fairytales = await getFairyTales();
-  await downloadMp3(fairytales[0].id, fairytales[0].title);
+  await downloadMp3(
+    fairytales[0].id,
+    fairytales[0].title,
+    fairytales[0].prettyDates.iso
+  );
 }
 
-// dowload last 10 fairytales 
-async function downloadLatest(last) {
-  const fairytales = await getFairyTales(last);
+// dowload last 10 fairytales
+async function downloadLatest(last, date) {
+  let fairytales = await getFairyTales(last);
+  // Revert the array
+  fairytales = fairytales.reverse();
+  // Remove objects from the array until fairy_tale.prettyDates.iso equals date
+  const index = fairytales.findIndex(
+    (fairy_tale) => fairy_tale.prettyDates.iso === date
+  );
+  if (index !== -1) {
+    fairytales = fairytales.slice(index + 1);
+  }
+  // Count how many objects remain in the array and log the number out
+  console.log(`Number of fairytales to download: ${fairytales.length}`);
+  // Initialize progress counter
+  let progressCounter = 0;
   // For is waiting for promise to resolve
   for (const fairy_tale of fairytales) {
     // Start and wait for file to be downloaded
-    await downloadMp3(fairy_tale.id, fairy_tale.title);
-    // Wait for 10 seconds after file is downloaded before it starts downloading the new one
-    await new Promise(resolve => setTimeout(resolve, 10000));
+    const fileExists = await downloadMp3(
+      fairy_tale.id,
+      fairy_tale.title,
+      fairy_tale.prettyDates.iso
+    );
+
+    if (!fileExists) {
+      // Wait for 10 seconds after file is downloaded before it starts downloading the new one
+      await new Promise((resolve) => setTimeout(resolve, 10000));
+    }
+    // Increment progress counter
+    progressCounter++;
+    // Calculate progress percentage
+    const progressPercentage = (progressCounter / fairytales.length) * 100;
+    // Log progress bar
+    if (!fileExists) {
+      console.log(
+        `Progress: ${progressPercentage.toFixed(2)}% - ${
+          fairy_tale.prettyDates.iso
+        }: ${fairy_tale.title} -> downloaded.`
+      );
+    }
   }
 }
+const argv = yargs(hideBin(process.argv)).argv;
 
-const argv = yargs(hideBin(process.argv)).argv
-
-if (typeof argv.latest !== 'undefined') {
+if (typeof argv.latest !== "undefined") {
   downloadLastFairyTale();
 } else {
-  var last = (typeof argv.last !== 'undefined') ? argv.last : 10;
-  last = last > 50 ? 50 : last
-  downloadLatest(last);
+  // Read date from date.txt file if it exists and is not empty
+  let date = null;
+  if (fs.existsSync("date.txt")) {
+    const fileContent = fs.readFileSync("date.txt", "utf8");
+    if (fileContent && !isNaN(Date.parse(fileContent))) {
+      date = fileContent;
+    }
+  }
+
+  if (date !== null) {
+    // Log the date read from the file
+    console.log(`Downloading from ${date} onwards`);
+  }
+
+  var last = typeof argv.last !== "undefined" ? argv.last : 1400;
+  // var date = typeof argv.date !== "undefined" ? argv.date : null;
+
+  // last = last > 200 ? 200 : last;
+  downloadLatest(last, date);
 }

--- a/fairytails.js
+++ b/fairytails.js
@@ -78,6 +78,11 @@ async function downloadMp3(id, title, date) {
   }
   if (downloadedTitles.includes(title)) {
     console.log(`Title "${title}" already exists in downloaded.txt.`);
+
+    fs.writeFile("date.txt", date, function (err) {
+      if (err) throw err;
+    });
+
     return true;
   }
 

--- a/fairytails.js
+++ b/fairytails.js
@@ -158,10 +158,15 @@ async function downloadLatest(last, date) {
   let progressCounter = 0;
   // For is waiting for promise to resolve
   for (const fairy_tale of fairytales) {
+    let title = fairy_tale.title;
+    // Check if title contains / and replace it with -
+    if (title.includes("/")) {
+      title = title.replace(/\//g, "-");
+    }
     // Start and wait for file to be downloaded
     const fileExists = await downloadMp3(
       fairy_tale.id,
-      fairy_tale.title,
+      title,
       fairy_tale.prettyDates.iso
     );
 
@@ -178,7 +183,7 @@ async function downloadLatest(last, date) {
       console.log(
         `Progress: ${progressPercentage.toFixed(2)}% - ${
           fairy_tale.prettyDates.iso
-        }: ${fairy_tale.title} -> downloaded.`
+        }: ${title} -> downloaded.`
       );
     }
   }


### PR DESCRIPTION
Updated the downloader to add support for file history and for it to be able to continue where it last finished...

You can runit simply with: `node fairytails.js` - it will fetch the list of last 1400 fairytales by default

It now adds two files while executing:

**date.txt** - it stores the last fairytale episode date that was successfully downloaded. Each time you rerun the script it will slice the fairitales (in cronological order) up until this date. So you are able to continue the downloading from where you left off - also easily enables you to download new fairitales since the last time you have run the script.

**downloaded.txt** - This one stores each successfully downloaded title into its own line in the file. That file is then used to check if the title was already downloaded - in that case it skips the download. What I have figured out is that after a few years they just recycle the fairytales and new ones are not added so often anymore. This way you are only downloading the titles that are missing in your collection.

I added this list into a file (versus checking the file names in the downloads folders) so that you can safely move your files elswere after they are successfully downloaded. There is no need to kep them in there as your history is stored in the mentioned file.